### PR TITLE
Enforce event order with the same PTS

### DIFF
--- a/compositor_pipeline/src/queue.rs
+++ b/compositor_pipeline/src/queue.rs
@@ -4,7 +4,6 @@ mod utils;
 mod video_queue;
 
 use std::{
-    cmp::{self, Ordering},
     collections::HashMap,
     fmt::Debug,
     sync::{Arc, Mutex},
@@ -218,31 +217,6 @@ impl Queue {
         self.scheduled_event_sender
             .send(ScheduledEvent { pts, callback })
             .unwrap();
-    }
-}
-
-impl PartialOrd for ScheduledEvent {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl cmp::Eq for ScheduledEvent {}
-
-impl cmp::PartialEq for ScheduledEvent {
-    fn eq(&self, other: &Self) -> bool {
-        self.pts.eq(&other.pts) && std::ptr::eq(&self.callback, &other.callback)
-    }
-}
-
-impl Ord for ScheduledEvent {
-    fn cmp(&self, other: &Self) -> Ordering {
-        // Invert duration compare to make heap return smallest values
-        match self.pts.cmp(&other.pts) {
-            Ordering::Less => Ordering::Greater,
-            Ordering::Equal => Ordering::Equal,
-            Ordering::Greater => Ordering::Less,
-        }
     }
 }
 


### PR DESCRIPTION
The current implementation is not deterministic if you schedule events with the same PTS. This PR is enforcing a specific behavior. If events have the same PTS they will be executed in the same order that they were delivered.