### PR TITLE
update deprecated github actions + add workflow dispatch to docs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -36,7 +36,7 @@ jobs:
                   node-version: 20
 
             - name: 📥 Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                   submodules: 'true'
 
@@ -75,7 +75,7 @@ jobs:
 
             - name: 📦 Upload failed snapshot test artifacts
               if: failure()
-              uses: actions/upload-artifact@v3
+              uses: actions/upload-artifact@v4
               with:
                   name: failed_snapshot_tests
                   path: failed_snapshot_tests

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -1,6 +1,7 @@
 name: deploy to gh-pages
 
 on:
+    workflow_dispatch: {}
     push:
         branches: [master]
         paths:
@@ -27,7 +28,7 @@ jobs:
                 working-directory: ./docs
         steps:
             - name: 📥 Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: 🛠 Install system dependencies
               run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - uses: hadolint/hadolint-action@v3.1.0
               with:

--- a/.github/workflows/package_for_release.yml
+++ b/.github/workflows/package_for_release.yml
@@ -15,17 +15,17 @@ jobs:
               uses: dtolnay/rust-toolchain@stable
 
             - name: 📥 Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: 📦 Package
               run: cargo run --bin package_for_release
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                 name: live_compositor_linux_x86_64.tar.gz
                 path: live_compositor_linux_x86_64.tar.gz
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                 name: live_compositor_with_web_renderer_linux_x86_64.tar.gz
                 path: live_compositor_with_web_renderer_linux_x86_64.tar.gz
@@ -73,7 +73,7 @@ jobs:
                   cd "/repo"
                   cargo run --bin package_for_release
                   cp *.tar.gz /artifacts
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                 name: live_compositor_linux_aarch64.tar.gz
                 path: artifacts/live_compositor_linux_aarch64.tar.gz
@@ -88,17 +88,17 @@ jobs:
               uses: dtolnay/rust-toolchain@stable
 
             - name: 📥 Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: 📦 Package
               run: cargo run --bin package_for_release
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                 name: live_compositor_darwin_x86_64.tar.gz
                 path: live_compositor_darwin_x86_64.tar.gz
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                 name: live_compositor_with_web_renderer_darwin_x86_64.tar.gz
                 path: live_compositor_with_web_renderer_darwin_x86_64.tar.gz
@@ -113,17 +113,17 @@ jobs:
               uses: dtolnay/rust-toolchain@stable
 
             - name: 📥 Checkout repo
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
 
             - name: 📦 Package
               run: cargo run --bin package_for_release
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                 name: live_compositor_darwin_aarch64.tar.gz
                 path: live_compositor_darwin_aarch64.tar.gz
 
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                 name: live_compositor_with_web_renderer_darwin_aarch64.tar.gz
                 path: live_compositor_with_web_renderer_darwin_aarch64.tar.gz

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -21,7 +21,7 @@ jobs:
 
         steps:
             - name: Checkout
-              uses: actions/checkout@v2
+              uses: actions/checkout@v4
 
             - name: shellcheck
               run: |


### PR DESCRIPTION
Closes #535 

Update deprecated actions
Add workflow_dispatch to docs deploy (sometimes we need to trigger manually)