### PR TITLE
Wgpu ctx init more friendly

### DIFF
--- a/compositor_render/src/wgpu/ctx.rs
+++ b/compositor_render/src/wgpu/ctx.rs
@@ -70,12 +70,12 @@ impl WgpuCtx {
             return Err(CreateWgpuCtxError::NoAdapter);
         }
         let required_features = wgpu::Features::TEXTURE_BINDING_ARRAY
-                    | wgpu::Features::PUSH_CONSTANTS
-                    | wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
-                    | wgpu::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;
+            | wgpu::Features::PUSH_CONSTANTS
+            | wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
+            | wgpu::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;
 
         let missing_features = required_features.difference(adapter.features());
-        if ! missing_features.is_empty() {
+        if !missing_features.is_empty() {
             error!("Selected adapter or it's driver don't support required {missing_features:?}. Aborting.");
             return Err(CreateWgpuCtxError::NoAdapter);
         }

--- a/compositor_render/src/wgpu/ctx.rs
+++ b/compositor_render/src/wgpu/ctx.rs
@@ -69,6 +69,16 @@ impl WgpuCtx {
             error!("Selected adapter is CPU based. Aborting.");
             return Err(CreateWgpuCtxError::NoAdapter);
         }
+        let required_features = wgpu::Features::TEXTURE_BINDING_ARRAY
+                    | wgpu::Features::PUSH_CONSTANTS
+                    | wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
+                    | wgpu::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;
+
+        let missing_features = required_features.difference(adapter.features());
+        if ! missing_features.is_empty() {
+            error!("Selected adapter or it's driver don't support required {missing_features:?}. Aborting.");
+            return Err(CreateWgpuCtxError::NoAdapter);
+        }
 
         let (device, queue) = pollster::block_on(adapter.request_device(
             &wgpu::DeviceDescriptor {
@@ -77,10 +87,7 @@ impl WgpuCtx {
                     max_push_constant_size: 128,
                     ..Default::default()
                 },
-                required_features: wgpu::Features::TEXTURE_BINDING_ARRAY
-                    | wgpu::Features::PUSH_CONSTANTS
-                    | wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
-                    | wgpu::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
+                required_features,
             },
             None,
         ))?;


### PR DESCRIPTION
By asking wgpu adapter.features() before adapter.request_device(..., required_features), don't let panic on missing feature but error!() and return Err(CreateWgpuCtxError::NoAdapter).
Output log contains no less nor more details with this PR. May create room to future improvements like : try another adapter or let start without some non-critical features.