### PR TITLE
Wgpu ctx init more laxist

### DIFF
--- a/compositor_render/src/wgpu/ctx.rs
+++ b/compositor_render/src/wgpu/ctx.rs
@@ -71,7 +71,7 @@ impl WgpuCtx {
         }
         let required_features =
             wgpu::Features::TEXTURE_BINDING_ARRAY | wgpu::Features::PUSH_CONSTANTS;
-        let nominal_mode_features =
+        let optional_features =
             wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
                 | wgpu::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;
 

--- a/compositor_render/src/wgpu/ctx.rs
+++ b/compositor_render/src/wgpu/ctx.rs
@@ -82,8 +82,7 @@ impl WgpuCtx {
         }
         let missing_nominal_mode_features = nominal_mode_features.difference(adapter.features());
         if !missing_nominal_mode_features.is_empty() {
-            error!("Selected adapter or it's driver don't support nominal mode wgpu {missing_nominal_mode_features:?}.");
-            error!("Starting in degraded mode, some valid and correct user shaders may not able to run on this adapter.");
+            error!("Selected adapter or its driver does not support optional wgpu features. Missing features: {missing_optional_features:?}).");
         }
         let required_features = critical_features
             .union(nominal_mode_features.difference(missing_nominal_mode_features));

--- a/compositor_render/src/wgpu/ctx.rs
+++ b/compositor_render/src/wgpu/ctx.rs
@@ -69,9 +69,8 @@ impl WgpuCtx {
             error!("Selected adapter is CPU based. Aborting.");
             return Err(CreateWgpuCtxError::NoAdapter);
         }
-        let critical_features = wgpu::Features::TEXTURE_BINDING_ARRAY
-            | wgpu::Features::TEXTURE_COMPRESSION_ETC2
-            | wgpu::Features::PUSH_CONSTANTS;
+        let critical_features =
+            wgpu::Features::TEXTURE_BINDING_ARRAY | wgpu::Features::PUSH_CONSTANTS;
         let nominal_mode_features =
             wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
                 | wgpu::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;

--- a/compositor_render/src/wgpu/ctx.rs
+++ b/compositor_render/src/wgpu/ctx.rs
@@ -69,6 +69,16 @@ impl WgpuCtx {
             error!("Selected adapter is CPU based. Aborting.");
             return Err(CreateWgpuCtxError::NoAdapter);
         }
+        let required_features = wgpu::Features::TEXTURE_BINDING_ARRAY
+                    | wgpu::Features::PUSH_CONSTANTS
+                    | wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
+                    | wgpu::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;
+
+        let missing_features = required_features.difference(adapter.features());
+        if ! missing_features.is_empty() {
+            error!("Selected adapter or it's driver don't support required {missing_features:?}. Aborting.");
+            return Err(CreateWgpuCtxError::NoAdapter);
+        }
 
         let (device, queue) = pollster::block_on(adapter.request_device(
             &wgpu::DeviceDescriptor {
@@ -77,10 +87,7 @@ impl WgpuCtx {
                     max_push_constant_size: 128,
                     ..Default::default()
                 },
-                required_features: wgpu::Features::TEXTURE_BINDING_ARRAY
-                    | wgpu::Features::PUSH_CONSTANTS
-                    | wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
-                    | wgpu::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING,
+                required_features,
             },
             None,
         ))?;

--- a/compositor_render/src/wgpu/ctx.rs
+++ b/compositor_render/src/wgpu/ctx.rs
@@ -70,23 +70,24 @@ impl WgpuCtx {
             return Err(CreateWgpuCtxError::NoAdapter);
         }
         let critical_features = wgpu::Features::TEXTURE_BINDING_ARRAY
-                    | wgpu::Features::TEXTURE_COMPRESSION_ETC2
-                    | wgpu::Features::PUSH_CONSTANTS;
+            | wgpu::Features::TEXTURE_COMPRESSION_ETC2
+            | wgpu::Features::PUSH_CONSTANTS;
         let nominal_mode_features =
-                    wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
-                    | wgpu::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;
+            wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
+                | wgpu::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;
 
         let missing_critical_features = critical_features.difference(adapter.features());
-        if ! missing_critical_features.is_empty() {
+        if !missing_critical_features.is_empty() {
             error!("Selected adapter or it's driver don't support critical wgpu {missing_critical_features:?}. Aborting.");
             return Err(CreateWgpuCtxError::NoAdapter);
         }
         let missing_nominal_mode_features = nominal_mode_features.difference(adapter.features());
-        if ! missing_nominal_mode_features.is_empty() {
+        if !missing_nominal_mode_features.is_empty() {
             error!("Selected adapter or it's driver don't support nominal mode wgpu {missing_nominal_mode_features:?}.");
             error!("Starting in degraded mode, some valid and correct user shaders may not able to run on this adapter.");
         }
-        let required_features = critical_features.union(nominal_mode_features.difference(missing_nominal_mode_features));
+        let required_features = critical_features
+            .union(nominal_mode_features.difference(missing_nominal_mode_features));
 
         let (device, queue) = pollster::block_on(adapter.request_device(
             &wgpu::DeviceDescriptor {

--- a/compositor_render/src/wgpu/ctx.rs
+++ b/compositor_render/src/wgpu/ctx.rs
@@ -69,7 +69,7 @@ impl WgpuCtx {
             error!("Selected adapter is CPU based. Aborting.");
             return Err(CreateWgpuCtxError::NoAdapter);
         }
-        let critical_features =
+        let required_features =
             wgpu::Features::TEXTURE_BINDING_ARRAY | wgpu::Features::PUSH_CONSTANTS;
         let nominal_mode_features =
             wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING

--- a/compositor_render/src/wgpu/ctx.rs
+++ b/compositor_render/src/wgpu/ctx.rs
@@ -69,16 +69,24 @@ impl WgpuCtx {
             error!("Selected adapter is CPU based. Aborting.");
             return Err(CreateWgpuCtxError::NoAdapter);
         }
-        let required_features = wgpu::Features::TEXTURE_BINDING_ARRAY
-                    | wgpu::Features::PUSH_CONSTANTS
-                    | wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
+        let critical_features = wgpu::Features::TEXTURE_BINDING_ARRAY
+                    | wgpu::Features::TEXTURE_COMPRESSION_ETC2
+                    | wgpu::Features::PUSH_CONSTANTS;
+        let nominal_mode_features =
+                    wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
                     | wgpu::Features::UNIFORM_BUFFER_AND_STORAGE_TEXTURE_ARRAY_NON_UNIFORM_INDEXING;
 
-        let missing_features = required_features.difference(adapter.features());
-        if ! missing_features.is_empty() {
-            error!("Selected adapter or it's driver don't support required {missing_features:?}. Aborting.");
+        let missing_critical_features = critical_features.difference(adapter.features());
+        if ! missing_critical_features.is_empty() {
+            error!("Selected adapter or it's driver don't support critical wgpu {missing_critical_features:?}. Aborting.");
             return Err(CreateWgpuCtxError::NoAdapter);
         }
+        let missing_nominal_mode_features = nominal_mode_features.difference(adapter.features());
+        if ! missing_nominal_mode_features.is_empty() {
+            error!("Selected adapter or it's driver don't support nominal mode wgpu {missing_nominal_mode_features:?}.");
+            error!("Starting in degraded mode, some valid and correct user shaders may not able to run on this adapter.");
+        }
+        let required_features = critical_features.union(nominal_mode_features.difference(missing_nominal_mode_features));
 
         let (device, queue) = pollster::block_on(adapter.request_device(
             &wgpu::DeviceDescriptor {

--- a/compositor_render/src/wgpu/ctx.rs
+++ b/compositor_render/src/wgpu/ctx.rs
@@ -77,7 +77,7 @@ impl WgpuCtx {
 
         let missing_critical_features = critical_features.difference(adapter.features());
         if !missing_critical_features.is_empty() {
-            error!("Selected adapter or it's driver don't support critical wgpu {missing_critical_features:?}. Aborting.");
+            error!("Selected adapter or its driver does not support required wgpu features. Missing features: {missing_critical_features:?}).");
             return Err(CreateWgpuCtxError::NoAdapter);
         }
         let missing_nominal_mode_features = nominal_mode_features.difference(adapter.features());


### PR DESCRIPTION
By splitting required_features into critical_features and nominal_mode_features and adding a bit of logic, let compositor start in a degraded mode on poor's man/hw instead of not running at all if it will affect only some functionalities of the compositor.