### PR TITLE
Handle EOS before first packet

### DIFF
--- a/compositor_pipeline/src/queue/utils.rs
+++ b/compositor_pipeline/src/queue/utils.rs
@@ -89,7 +89,10 @@ impl<Payload: InputProcessorMediaExt> InputProcessor<Payload> {
 
     fn handle_eos(&mut self) -> VecDeque<Payload> {
         match self.state {
-            InputState::WaitingForStart => VecDeque::new(),
+            InputState::WaitingForStart => {
+                self.state = InputState::Done;
+                VecDeque::new()
+            }
             InputState::Buffering { ref mut buffer } => {
                 let first_pts = buffer.first().map(|(_, p)| *p).unwrap_or(Duration::ZERO);
                 let chunks = mem::take(buffer)


### PR DESCRIPTION
If EOS was received before first packet it never transitioned to Done state, so if stream was required it might block the queue indefinietlly.