### PR TITLE
Demos recording fix h265 -> h264

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Input audio can be mixed directly in LiveCompositor, providing synchronization f
 
 ## Demos
 
-https://github.com/membraneframework/live_compositor/assets/104033489/44cfa3a8-bb92-4f90-b563-a028bf7f3efa
+https://github.com/membraneframework/live_compositor/assets/104033489/e6f5ba7c-ab05-4935-a42a-bc28c42fc895
 
 TypeScript demos presenting what you can do with LiveCompositor are available in the `demos` directory.
 


### PR DESCRIPTION
Firefox and older versions of Chrome don't support h265