### PR TITLE
Fix pottentially flaky integration test

### DIFF
--- a/integration_tests/src/tests/schedule_update.rs
+++ b/integration_tests/src/tests/schedule_update.rs
@@ -107,6 +107,7 @@ pub fn schedule_update() -> Result<()> {
             "video": {
                 "decoder": "ffmpeg_h264"
             },
+            "required": true,
             "offset_ms": 0,
         }),
     )?;
@@ -120,6 +121,7 @@ pub fn schedule_update() -> Result<()> {
             "video": {
                 "decoder": "ffmpeg_h264"
             },
+            "required": true,
             "offset_ms": 0,
         }),
     )?;


### PR DESCRIPTION
It is testing scheduled updates, so it's fine to make streams required without affecting what is tested