### PR TITLE
[website] Update contact us section

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -451,27 +451,14 @@ function ContactUs() {
               </Heading>
             </div>
             <div className="card__body">
-              <p className={styles.sectionSubheading}>
+              <p className={clsx(styles.sectionSubheading, 'margin-bottom--md')}>
                 LiveCompositor is developed by Software Mansion - a software company that is
                 specialized in building tools for developers. At Software Mansion, we work on
                 multiple multimedia projects, like Membrane Framework, Elixir WebRTC, FishJam, and
-                more. We also work on custom solutions for clients. Contact us and create something
-                together.
+                more. We also work on custom solutions for clients. Email us at{' '}
+                <Link to="mailto:projects@swmansion.com">projects@swmansion.com</Link> or contact us
+                via <Link to="https://membrane.stream/contact">this form</Link>.
               </p>
-              <div className="row" style={{ justifyContent: 'end' }}>
-                <Link
-                  className={clsx(
-                    'button',
-                    'button--primary',
-                    'button--lg',
-                    'margin--sm',
-                    styles.smallScreenFlexButton,
-                    styles.hoverPrimary
-                  )}
-                  to="https://membrane.stream/contact">
-                  Contact us
-                </Link>
-              </div>
             </div>
           </div>
         </div>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -45,8 +45,7 @@ function HomepageHeader() {
               </div>
             </Heading>
             <p className={styles.sectionSubheading}>
-              Open-source media server for real-time, low latency, programmable video and audio
-              mixing.
+              Media server for real-time, low latency, programmable video and audio mixing.
             </p>
             <div className="row margin-bottom--md">
               <Link


### PR DESCRIPTION
Addressing https://github.com/membraneframework/live_compositor/pull/590#discussion_r1634966646

I think listing email with that contatct us button would be wierd, so I removed button and made both links to be just texts. I'm not super happy how this looks, I'm open to other suggestions.

![20240611_17h07m56s_grim](https://github.com/membraneframework/live_compositor/assets/9753141/1f48af84-4c2c-4c8f-b9d6-5dca9069ac10)
