### PR TITLE
Some DeckLink profile attributes should not be freed

### DIFF
--- a/decklink/Cargo.toml
+++ b/decklink/Cargo.toml
@@ -2,6 +2,7 @@
 name = "decklink"
 version = "0.1.0"
 edition = "2021"
+license = "BUSL-1.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/decklink/src/api/profile.rs
+++ b/decklink/src/api/profile.rs
@@ -41,8 +41,15 @@ impl ProfileAttributes {
     }
 
     pub fn get_string(&self, id: ffi::StringAttributeId) -> Result<Option<String>, DeckLinkError> {
+        // List of attributes that should not be freed
+        const STATIC_STRING_ATTRIBUTES: [ffi::StringAttributeId; 1] =
+            [ffi::StringAttributeId::VendorName];
+
+        let is_static = STATIC_STRING_ATTRIBUTES
+            .iter()
+            .any(|static_id| static_id == &id);
         let mut value = String::new();
-        match unsafe { ffi::profile_attributes_string(self.0, id, &mut value, false)? } {
+        match unsafe { ffi::profile_attributes_string(self.0, id, &mut value, is_static)? } {
             HResult::NotImplementedError => Ok(None),
             hresult => {
                 hresult.into_result("IDeckLinkProfileAttributes::GetString")?;


### PR DESCRIPTION
It was not crashing, but according to docs some string attributes should not be freed.