### PR TITLE
Select DeckLink by persistent ID + add override for pixel format

### DIFF
--- a/compositor_pipeline/src/pipeline/input/decklink.rs
+++ b/compositor_pipeline/src/pipeline/input/decklink.rs
@@ -10,24 +10,39 @@ use super::{AudioInputReceiver, Input, InputInitInfo, InputInitResult, VideoInpu
 mod capture;
 mod find_device;
 
+pub use decklink::PixelFormat;
+
 const AUDIO_SAMPLE_RATE: u32 = 48_000;
 
 #[derive(Debug, thiserror::Error)]
 pub enum DeckLinkError {
     #[error("Unknown DeckLink error.")]
     DecklinkError(#[from] decklink::DeckLinkError),
-    #[error("No DeckLink device matches specified options.")]
-    NoMatchingDeckLink,
+    #[error("No DeckLink device matches specified options. Found devices: {0:?}")]
+    NoMatchingDeckLink(Vec<DeckLinkInfo>),
     #[error("Selected device does not support capture.")]
     NoCaptureSupport,
     #[error("Selected device does not support input format detection.")]
     NoInputFormatDetection,
 }
 
+#[derive(Debug)]
+pub struct DeckLinkInfo {
+    pub display_name: Option<String>,
+    pub persistent_id: Option<String>,
+    pub subdevice_index: Option<u32>,
+}
+
 pub struct DeckLinkOptions {
     pub subdevice_index: Option<u32>,
     pub display_name: Option<String>,
+    /// Persistent id of a device (different value for each sub-device).
+    pub persistent_id: Option<u32>,
+
     pub enable_audio: bool,
+    /// Force specified pixel format, value resolved in input format
+    /// autodetection will be ignored.
+    pub pixel_format: Option<PixelFormat>,
 }
 
 pub struct DeckLink {
@@ -62,6 +77,7 @@ impl DeckLink {
         let (callback, receivers) = ChannelCallbackAdapter::new(
             span,
             opts.enable_audio,
+            opts.pixel_format,
             Arc::<decklink::Input>::downgrade(&input),
         );
         input.set_callback(Box::new(callback))?;

--- a/compositor_pipeline/src/pipeline/input/decklink/find_device.rs
+++ b/compositor_pipeline/src/pipeline/input/decklink/find_device.rs
@@ -2,17 +2,34 @@ use decklink::{
     get_decklinks, FlagAttributeId, IntegerAttributeId, StringAttributeId, VideoIOSupport,
 };
 
-use super::{DeckLinkError, DeckLinkOptions};
+use super::{DeckLinkError, DeckLinkInfo, DeckLinkOptions};
 
 pub(super) fn find_decklink(opts: &DeckLinkOptions) -> Result<decklink::DeckLink, DeckLinkError> {
     let decklinks = get_decklinks()?;
+
+    let decklinks_info = decklinks
+        .iter()
+        .map(|decklink| {
+            let attr = decklink.profile_attributes()?;
+            Ok(DeckLinkInfo {
+                display_name: attr.get_string(StringAttributeId::DisplayName)?,
+                persistent_id: attr
+                    .get_integer(IntegerAttributeId::PersistentID)?
+                    .map(|value| format!("{value:X}")),
+                subdevice_index: attr
+                    .get_integer(IntegerAttributeId::SubDeviceIndex)?
+                    .map(|i| i as u32),
+            })
+        })
+        .collect::<Result<_, DeckLinkError>>()?;
 
     for mut decklink in decklinks.into_iter() {
         if is_selected_decklink(opts, &mut decklink)? {
             return Ok(decklink);
         }
     }
-    Err(DeckLinkError::NoMatchingDeckLink)
+
+    Err(DeckLinkError::NoMatchingDeckLink(decklinks_info))
 }
 
 fn is_selected_decklink(
@@ -29,6 +46,12 @@ fn is_selected_decklink(
 
     if let Some(display_name) = &opts.display_name {
         if attr.get_string(StringAttributeId::DisplayName)?.as_ref() != Some(display_name) {
+            return Ok(false);
+        }
+    }
+
+    if let Some(persistent_id) = opts.persistent_id {
+        if attr.get_integer(IntegerAttributeId::PersistentID)? != Some(persistent_id as i64) {
             return Ok(false);
         }
     }

--- a/decklink/src/info.rs
+++ b/decklink/src/info.rs
@@ -67,6 +67,7 @@ pub struct ProfileAttributesInfo {
 
     pub subdevice_index: Option<i64>,
     pub persistent_id: Option<i64>,
+    pub persistent_id_hex_str: Option<String>,
     pub device_group_id: Option<i64>,
     pub topological_id: Option<i64>,
 
@@ -91,6 +92,9 @@ impl ProfileAttributes {
             number_of_subdevices: self.get_integer(IntegerAttributeId::NumberOfSubDevices)?,
             subdevice_index: self.get_integer(IntegerAttributeId::SubDeviceIndex)?,
             persistent_id: self.get_integer(IntegerAttributeId::PersistentID)?,
+            persistent_id_hex_str: self
+                .get_integer(IntegerAttributeId::PersistentID)?
+                .map(|value| format!("{value:X}")),
             device_group_id: self.get_integer(IntegerAttributeId::DeviceGroupID)?,
             topological_id: self.get_integer(IntegerAttributeId::TopologicalID)?,
 

--- a/src/types/from_register_input.rs
+++ b/src/types/from_register_input.rs
@@ -171,11 +171,28 @@ impl TryFrom<DeckLink> for pipeline::RegisterInputOptions {
 
     #[cfg(feature = "decklink")]
     fn try_from(value: DeckLink) -> Result<Self, Self::Error> {
+        use compositor_pipeline::pipeline::input::decklink;
+
+        const ID_PARSE_ERROR_MESSAGE: &str =
+            "\"persistent_id\" has to be a valid 32-bit hexadecimal number";
+
+        let persistent_id = match value.persistent_id {
+            Some(persistent_id) => {
+                let Ok(persistent_id) = u32::from_str_radix(&persistent_id, 16) else {
+                    return Err(TypeError::new(ID_PARSE_ERROR_MESSAGE));
+                };
+                Some(persistent_id)
+            }
+            None => None,
+        };
+
         Ok(pipeline::RegisterInputOptions {
             input_options: input::InputOptions::DeckLink(input::decklink::DeckLinkOptions {
                 subdevice_index: value.subdevice_index,
                 display_name: value.display_name,
+                persistent_id,
                 enable_audio: value.enable_audio.unwrap_or(true),
+                pixel_format: Some(decklink::PixelFormat::Format8BitYUV),
             }),
             queue_options: queue::QueueInputOptions {
                 required: value.required.unwrap_or(false),

--- a/src/types/register_input.rs
+++ b/src/types/register_input.rs
@@ -51,16 +51,25 @@ pub struct DeckLink {
     /// Single DeckLink device can consist of multiple sub-devices. This field defines
     /// index of sub-device that should be used.
     ///
-    /// When selecting an input device both `subdevice_index` **AND** `display_name` fields need
-    /// to match if they are specified.
+    /// The input device is selected based on fields `subdevice_index`, `persistent_id` **AND** `display_name`.
+    /// All of them need to match the device if they are specified. If nothing is matched, the error response
+    /// will list available devices.
     pub subdevice_index: Option<u32>,
 
     /// Select sub-device to use based on the display name. This is the value you see in e.g.
     /// Blackmagic Media Express app. like "DeckLink Quad HDMI Recorder (3)"
     ///
-    /// When selecting an input both `subdevice_index` **AND** `display_name` fields need
-    /// to match if they are specified.
+    /// The input device is selected based on fields `subdevice_index`, `persistent_id` **AND** `display_name`.
+    /// All of them need to match the device if they are specified. If nothing is matched, the error response
+    /// will list available devices.
     pub display_name: Option<String>,
+
+    /// Persistent ID of a device represented by 32-bit hex number. Each DeckLink sub-device has a separate id.
+    ///
+    /// The input device is selected based on fields `subdevice_index`, `persistent_id` **AND** `display_name`.
+    /// All of them need to match the device if they are specified. If nothing is matched, the error response
+    /// will list available devices.
+    pub persistent_id: Option<String>,
 
     /// (**default=`true`**) Enable audio support.
     pub enable_audio: Option<bool>,


### PR DESCRIPTION
- Add an option to specify the persistent id of the DeckLink device
  - REST API expects hex string
  - internally it's just an integer
  - Error messages/responses will return string variant when no device is matched correctly
- Add an internal option to enforce pixel format (from REST API it is always forcing YUV422 8 bit)
  - If the device supports 10-bit and 8-bit yuv it usually defaults to 10-bit which is not supported in compositor.
- If no DeckLink device is matched correctly, the error message will include a list of all Decklink devices


Example error message in case of mismatch
```
Error stack:
 - Input initialization error while registering input for stream "input_1".
 - No DeckLink device matches specified options. Found devices: [DeckLinkInfo { display_name: Some("DeckLink Quad HDMI Recorder (1)"), persistent_id: Some("DEEB490"), subdevice_index: Some(0) }, DeckLinkInfo { display_name: Some("DeckLink Quad HDMI Recorder (2)"), persistent_id: Some("DEEB491"), subdevice_index: Some(1) }, DeckLinkInfo { display_name: Some("DeckLink Quad HDMI Recorder (3)"), persistent_id: Some("DEEB492"), subdevice_index: Some(2) }, DeckLinkInfo { display_name: Some("DeckLink Quad HDMI Recorder (4)"), persistent_id: Some("DEEB493"), subdevice_index: Some(3) }]
 ```