### PR TITLE
Ignore DeckLink format changes if pixel format is forced

### DIFF
--- a/compositor_pipeline/src/pipeline/input/decklink.rs
+++ b/compositor_pipeline/src/pipeline/input/decklink.rs
@@ -79,6 +79,10 @@ impl DeckLink {
             opts.enable_audio,
             opts.pixel_format,
             Arc::<decklink::Input>::downgrade(&input),
+            (
+                decklink::DisplayModeType::ModeHD720p50,
+                decklink::PixelFormat::Format8BitYUV,
+            ),
         );
         input.set_callback(Box::new(callback))?;
         input.start_streams()?;


### PR DESCRIPTION
When we force pixel format, the format changed notification is sent again after the first frame. To avoid that I'm recording previous format and only reset streams if the format should be changed