### PR TITLE
Add function simplifying creating new test examples

### DIFF
--- a/compositor_pipeline/src/queue.rs
+++ b/compositor_pipeline/src/queue.rs
@@ -64,6 +64,7 @@ pub struct Queue {
     clock: Clock,
 }
 
+#[derive(Debug)]
 pub(super) struct QueueVideoOutput {
     pub(super) pts: Duration,
     pub(super) frames: HashMap<InputId, PipelineEvent<Frame>>,

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -10,7 +10,11 @@ license = "BUSL-1.1"
 default = ["web_renderer"]
 update_snapshots = []
 decklink = ["live_compositor/decklink"]
-web_renderer = ["dep:compositor_chromium", "live_compositor/web_renderer"]
+web_renderer = [
+    "dep:compositor_chromium",
+    "compositor_render/web_renderer",
+    "live_compositor/web_renderer",
+]
 
 [dependencies]
 live_compositor = { workspace = true }

--- a/integration_tests/examples/decklink.rs
+++ b/integration_tests/examples/decklink.rs
@@ -1,15 +1,12 @@
 use anyhow::Result;
 use compositor_api::types::Resolution;
-use live_compositor::server;
-use log::{error, info};
 use serde_json::json;
-use std::{
-    process::{Command, Stdio},
-    thread,
-    time::Duration,
-};
+use std::time::Duration;
 
-use integration_tests::examples::{self, start_websocket_thread};
+use integration_tests::{
+    examples::{self, run_example},
+    gstreamer::start_gst_receive_tcp,
+};
 
 const VIDEO_RESOLUTION: Resolution = Resolution {
     width: 1280,
@@ -20,23 +17,10 @@ const IP: &str = "127.0.0.1";
 const OUTPUT_VIDEO_PORT: u16 = 8002;
 
 fn main() {
-    ffmpeg_next::format::network::init();
-
-    thread::spawn(|| {
-        if let Err(err) = start_example_client_code() {
-            error!("{err}")
-        }
-    });
-
-    server::run();
+    run_example(client_code);
 }
 
-fn start_example_client_code() -> Result<()> {
-    info!("[example] Start listening on output port.");
-    thread::sleep(Duration::from_secs(2));
-    start_websocket_thread();
-
-    info!("[example] Send register input request.");
+fn client_code() -> Result<()> {
     examples::post(
         "input/input_1/register",
         &json!({
@@ -46,7 +30,6 @@ fn start_example_client_code() -> Result<()> {
         }),
     )?;
 
-    info!("[example] Send register output video request.");
     examples::post(
         "output/output_1/register",
         &json!({
@@ -97,23 +80,10 @@ fn start_example_client_code() -> Result<()> {
         }),
     )?;
 
-    let gst_output_command =  [
-        "gst-launch-1.0 -v ",
-        "rtpptdemux name=demux ",
-        &format!("tcpclientsrc host={IP} port={OUTPUT_VIDEO_PORT} ! \"application/x-rtp-stream\" ! rtpstreamdepay ! queue ! demux. "),
-        "demux.src_96 ! \"application/x-rtp,media=video,clock-rate=90000,encoding-name=H264\" ! queue ! rtph264depay ! decodebin ! videoconvert ! autovideosink ",
-        "demux.src_97 ! \"application/x-rtp,media=audio,clock-rate=48000,encoding-name=OPUS\" ! queue ! rtpopusdepay ! decodebin ! audioconvert ! autoaudiosink ",
-    ].concat();
-    Command::new("bash")
-        .arg("-c")
-        .arg(gst_output_command)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()?;
+    start_gst_receive_tcp(IP, OUTPUT_VIDEO_PORT, true, false)?;
 
     std::thread::sleep(Duration::from_millis(1000));
 
-    info!("[example] Start pipeline");
     examples::post("start", &json!({}))?;
 
     Ok(())

--- a/integration_tests/examples/docker.rs
+++ b/integration_tests/examples/docker.rs
@@ -6,8 +6,9 @@ use serde_json::json;
 use signal_hook::{consts, iterator::Signals};
 use std::{env, process::Command, thread, time::Duration};
 
-use integration_tests::examples::{
-    self, start_ffplay, start_websocket_thread, stream_ffmpeg_testsrc,
+use integration_tests::{
+    examples::{self, start_server_msg_listener, TestSample},
+    ffmpeg::{start_ffmpeg_receive, start_ffmpeg_send},
 };
 const VIDEO_RESOLUTION: Resolution = Resolution {
     width: 1920,
@@ -17,6 +18,10 @@ const VIDEO_RESOLUTION: Resolution = Resolution {
 const IP: &str = "127.0.0.1";
 const INPUT_PORT: u16 = 8002;
 const OUTPUT_PORT: u16 = 8004;
+const DOCKER_FILE_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../build_tools/docker/slim.Dockerfile"
+);
 
 fn main() {
     let Ok(host_ip) = env::var("DOCKER_HOST_IP") else {
@@ -53,7 +58,7 @@ fn build_and_start_docker(skip_build: bool) -> Result<()> {
             .args([
                 "build",
                 "-f",
-                "../build_tools/docker/slim.Dockerfile",
+                DOCKER_FILE_PATH,
                 "-t",
                 "video-compositor",
                 ".",
@@ -97,11 +102,9 @@ fn build_and_start_docker(skip_build: bool) -> Result<()> {
 fn start_example_client_code(host_ip: String) -> Result<()> {
     thread::sleep(Duration::from_secs(5));
 
-    info!("[example] Start listening on output port.");
-    start_ffplay(&host_ip, OUTPUT_PORT, None)?;
-    start_websocket_thread();
+    start_ffmpeg_receive(Some(OUTPUT_PORT), None)?;
+    start_server_msg_listener();
 
-    info!("[example] Send register input request.");
     examples::post(
         "input/input_1/register",
         &json!({
@@ -114,7 +117,6 @@ fn start_example_client_code(host_ip: String) -> Result<()> {
     )?;
 
     let shader_source = include_str!("./silly.wgsl");
-    info!("[example] Register shader transform");
     examples::post(
         "shader/example_shader/register",
         &json!({
@@ -122,7 +124,6 @@ fn start_example_client_code(host_ip: String) -> Result<()> {
         }),
     )?;
 
-    info!("[example] Send register output request.");
     examples::post(
         "output/output_1/register",
         &json!({
@@ -155,11 +156,9 @@ fn start_example_client_code(host_ip: String) -> Result<()> {
         }),
     )?;
 
-    info!("[example] Start pipeline");
     examples::post("start", &json!({}))?;
 
-    info!("[example] Start input stream");
-    stream_ffmpeg_testsrc(IP, INPUT_PORT, VIDEO_RESOLUTION)?;
+    start_ffmpeg_send(IP, Some(INPUT_PORT), None, TestSample::TestPattern)?;
 
     Ok(())
 }

--- a/integration_tests/examples/encoded_channel_output.rs
+++ b/integration_tests/examples/encoded_channel_output.rs
@@ -95,7 +95,7 @@ fn main() {
 
     let input_options = RegisterInputOptions {
         input_options: InputOptions::Mp4(Mp4Options {
-            source: Source::File(root_dir.join("examples/assets/BigBuckBunny.mp4")),
+            source: Source::File(root_dir.join(BUNNY_FILE_PATH)),
         }),
         queue_options: QueueInputOptions {
             required: true,

--- a/integration_tests/examples/image.rs
+++ b/integration_tests/examples/image.rs
@@ -1,39 +1,27 @@
 use anyhow::Result;
 use compositor_api::types::Resolution;
-use live_compositor::server;
-use log::{error, info};
 use serde_json::json;
-use std::{env, path::PathBuf, thread};
+use std::{env, path::PathBuf};
 
-use integration_tests::examples::{self, start_ffplay, start_websocket_thread};
+use integration_tests::{
+    examples::{self, run_example},
+    ffmpeg::start_ffmpeg_receive,
+};
 
 const VIDEO_RESOLUTION: Resolution = Resolution {
     width: 1920,
     height: 1080,
 };
 
-const IP: &str = "127.0.0.1";
 const OUTPUT_PORT: u16 = 8002;
 
 fn main() {
-    env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
-    ffmpeg_next::format::network::init();
-
-    thread::spawn(|| {
-        if let Err(err) = start_example_client_code() {
-            error!("{err}")
-        }
-    });
-
-    server::run()
+    run_example(client_code);
 }
 
-fn start_example_client_code() -> Result<()> {
-    info!("[example] Start listening on output port.");
-    start_ffplay(IP, OUTPUT_PORT, None)?;
-    start_websocket_thread();
+fn client_code() -> Result<()> {
+    start_ffmpeg_receive(Some(OUTPUT_PORT), None)?;
 
-    info!("[example] Register static images");
     examples::post(
         "image/example_gif/register",
         &json!({
@@ -107,7 +95,6 @@ fn start_example_client_code() -> Result<()> {
         ]
     });
 
-    info!("[example] Send register output request.");
     examples::post(
         "output/output_1/register",
         &json!({
@@ -130,7 +117,6 @@ fn start_example_client_code() -> Result<()> {
         }),
     )?;
 
-    info!("[example] Start pipeline");
     examples::post("start", &json!({}))?;
 
     Ok(())

--- a/integration_tests/examples/pass_through.rs
+++ b/integration_tests/examples/pass_through.rs
@@ -1,16 +1,13 @@
 use anyhow::Result;
 use compositor_api::types::Resolution;
-use live_compositor::server;
-use log::{error, info};
 use serde_json::json;
-use std::{env, thread, time::Duration};
+use std::time::Duration;
 
-use integration_tests::examples::{
-    self, download_file, start_ffplay, start_websocket_thread, stream_video,
+use integration_tests::{
+    examples::{self, run_example, TestSample},
+    ffmpeg::{start_ffmpeg_receive, start_ffmpeg_send},
 };
 
-const SAMPLE_FILE_URL: &str = "https://filesamples.com/samples/video/mp4/sample_1280x720.mp4";
-const SAMPLE_FILE_PATH: &str = "examples/assets/sample_1280_720.mp4";
 const VIDEO_RESOLUTION: Resolution = Resolution {
     width: 1280,
     height: 720,
@@ -21,27 +18,12 @@ const INPUT_PORT: u16 = 8002;
 const OUTPUT_PORT: u16 = 8004;
 
 fn main() {
-    env::set_var("LIVE_COMPOSITOR_WEB_RENDERER_ENABLE", "0");
-    ffmpeg_next::format::network::init();
-
-    thread::spawn(|| {
-        if let Err(err) = start_example_client_code() {
-            error!("{err}")
-        }
-    });
-
-    server::run()
+    run_example(client_code);
 }
 
-fn start_example_client_code() -> Result<()> {
-    info!("[example] Start listening on output port.");
-    start_ffplay(IP, OUTPUT_PORT, None)?;
-    start_websocket_thread();
+fn client_code() -> Result<()> {
+    start_ffmpeg_receive(Some(OUTPUT_PORT), None)?;
 
-    info!("[example] Download sample.");
-    let sample_path = download_file(SAMPLE_FILE_URL, SAMPLE_FILE_PATH)?;
-
-    info!("[example] Send register input request.");
     examples::post(
         "input/input_1/register",
         &json!({
@@ -53,7 +35,6 @@ fn start_example_client_code() -> Result<()> {
         }),
     )?;
 
-    info!("[example] Send register output request.");
     examples::post(
         "output/output_1/register",
         &json!({
@@ -82,9 +63,8 @@ fn start_example_client_code() -> Result<()> {
 
     std::thread::sleep(Duration::from_millis(500));
 
-    info!("[example] Start pipeline");
     examples::post("start", &json!({}))?;
 
-    stream_video(IP, INPUT_PORT, sample_path)?;
+    start_ffmpeg_send(IP, Some(INPUT_PORT), None, TestSample::SampleLoop)?;
     Ok(())
 }

--- a/integration_tests/examples/raw_channel_input.rs
+++ b/integration_tests/examples/raw_channel_input.rs
@@ -1,5 +1,5 @@
 use core::panic;
-use std::{process::Command, sync::Arc, thread, time::Duration};
+use std::{sync::Arc, thread, time::Duration};
 
 use compositor_pipeline::{
     pipeline::{
@@ -22,7 +22,7 @@ use compositor_render::{
     scene::{Component, InputStreamComponent},
     Frame, FrameData, InputId, OutputId, Resolution,
 };
-use integration_tests::test_input::TestInput;
+use integration_tests::{gstreamer::start_gst_receive_tcp, test_input::TestInput};
 use live_compositor::{
     config::{read_config, LoggerConfig, LoggerFormat},
     logger::{self, FfmpegLogLevel},
@@ -105,12 +105,7 @@ fn main() {
 
     let frames = generate_frames(&wgpu_device, &wgpu_queue);
 
-    let gst_output_command = format!("gst-launch-1.0 -v tcpclientsrc host=127.0.0.1 port={VIDEO_OUTPUT_PORT} ! \"application/x-rtp-stream\" ! rtpstreamdepay ! rtph264depay ! decodebin ! videoconvert ! autovideosink");
-    Command::new("bash")
-        .arg("-c")
-        .arg(gst_output_command)
-        .spawn()
-        .unwrap();
+    start_gst_receive_tcp("127.0.0.1", VIDEO_OUTPUT_PORT, true, false).unwrap();
 
     Pipeline::start(&state.pipeline);
 

--- a/integration_tests/examples/raw_channel_output.rs
+++ b/integration_tests/examples/raw_channel_output.rs
@@ -94,7 +94,7 @@ fn main() {
 
     let input_options = RegisterInputOptions {
         input_options: InputOptions::Mp4(Mp4Options {
-            source: Source::File(root_dir().join("examples/assets/BigBuckBunny.mp4")),
+            source: Source::File(root_dir().join(BUNNY_FILE_PATH)),
         }),
         queue_options: QueueInputOptions {
             required: true,

--- a/integration_tests/examples/simple.rs
+++ b/integration_tests/examples/simple.rs
@@ -1,16 +1,13 @@
 use anyhow::Result;
 use compositor_api::types::Resolution;
-use live_compositor::server;
-use log::{error, info};
 use serde_json::json;
-use std::{thread, time::Duration};
+use std::time::Duration;
 
-use integration_tests::examples::{
-    self, download_file, start_ffplay, start_websocket_thread, stream_video,
+use integration_tests::{
+    examples::{self, run_example, TestSample},
+    ffmpeg::{start_ffmpeg_receive, start_ffmpeg_send},
 };
 
-const SAMPLE_FILE_URL: &str = "https://filesamples.com/samples/video/mp4/sample_1280x720.mp4";
-const SAMPLE_FILE_PATH: &str = "examples/assets/sample_1280_720.mp4";
 const VIDEO_RESOLUTION: Resolution = Resolution {
     width: 1280,
     height: 720,
@@ -21,27 +18,12 @@ const INPUT_PORT: u16 = 8002;
 const OUTPUT_PORT: u16 = 8004;
 
 fn main() {
-    ffmpeg_next::format::network::init();
-
-    thread::spawn(|| {
-        if let Err(err) = start_example_client_code() {
-            error!("{err}")
-        }
-    });
-
-    server::run();
+    run_example(client_code);
 }
 
-fn start_example_client_code() -> Result<()> {
-    info!("[example] Start listening on output port.");
-    start_ffplay(IP, OUTPUT_PORT, None)?;
-    thread::sleep(Duration::from_secs(2));
-    start_websocket_thread();
+fn client_code() -> Result<()> {
+    start_ffmpeg_receive(Some(OUTPUT_PORT), None)?;
 
-    info!("[example] Download sample.");
-    let sample_path = download_file(SAMPLE_FILE_URL, SAMPLE_FILE_PATH)?;
-
-    info!("[example] Send register input request.");
     examples::post(
         "input/input_1/register",
         &json!({
@@ -54,7 +36,6 @@ fn start_example_client_code() -> Result<()> {
     )?;
 
     let shader_source = include_str!("./silly.wgsl");
-    info!("[example] Register shader transform");
     examples::post(
         "shader/shader_example_1/register",
         &json!({
@@ -62,7 +43,6 @@ fn start_example_client_code() -> Result<()> {
         }),
     )?;
 
-    info!("[example] Send register output request.");
     examples::post(
         "output/output_1/register",
         &json!({
@@ -99,9 +79,8 @@ fn start_example_client_code() -> Result<()> {
 
     std::thread::sleep(Duration::from_millis(500));
 
-    info!("[example] Start pipeline");
     examples::post("start", &json!({}))?;
 
-    stream_video(IP, INPUT_PORT, sample_path)?;
+    start_ffmpeg_send(IP, Some(INPUT_PORT), None, TestSample::SampleLoop)?;
     Ok(())
 }

--- a/integration_tests/src/ffmpeg.rs
+++ b/integration_tests/src/ffmpeg.rs
@@ -1,0 +1,317 @@
+use anyhow::{anyhow, Result};
+use compositor_api::types::Resolution;
+use log::info;
+
+use super::examples::{get_asset_path, TestSample};
+use std::{
+    fs::File,
+    io::Write,
+    path::PathBuf,
+    process::{Command, Stdio},
+    thread,
+    time::Duration,
+};
+
+pub fn start_ffmpeg_receive(video_port: Option<u16>, audio_port: Option<u16>) -> Result<()> {
+    let output_sdp_path = match (video_port, audio_port) {
+        (Some(video_port), Some(audio_port)) => {
+            info!(
+                "[example] Start listening video on port {video_port} and audio on {audio_port}."
+            );
+            write_video_audio_example_sdp_file(video_port, audio_port)
+        }
+        (Some(video_port), None) => {
+            info!("[example] Start listening video on port {video_port}.");
+            write_video_example_sdp_file(video_port)
+        }
+        (None, Some(audio_port)) => {
+            info!("[example] Start listening audio on {audio_port}.");
+            write_audio_example_sdp_file(audio_port)
+        }
+        (None, None) => {
+            return Err(anyhow!(
+                "At least one of: 'video_port', 'audio_port' has to be specified."
+            ))
+        }
+    }?;
+
+    Command::new("ffplay")
+        .args(["-protocol_whitelist", "file,rtp,udp", &output_sdp_path])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    thread::sleep(Duration::from_secs(2));
+
+    Ok(())
+}
+
+pub fn start_ffmpeg_send(
+    ip: &str,
+    video_port: Option<u16>,
+    audio_port: Option<u16>,
+    test_sample: TestSample,
+) -> Result<()> {
+    match test_sample {
+        TestSample::BigBuckBunny | TestSample::ElephantsDream => {
+            start_ffmpeg_send_from_file(ip, video_port, audio_port, get_asset_path(test_sample)?)
+        }
+        TestSample::BigBuckBunnyAAC => start_ffmpeg_send_from_file_aac(
+            ip,
+            video_port,
+            audio_port,
+            get_asset_path(test_sample)?,
+        ),
+        TestSample::Sample => match video_port {
+            Some(port) => start_ffmpeg_send_video_from_file(ip, port, get_asset_path(test_sample)?),
+            None => Err(anyhow!("video port required for test sample")),
+        },
+        TestSample::SampleLoop => match video_port {
+            Some(port) => {
+                start_ffmpeg_send_video_from_file_loop(ip, port, get_asset_path(test_sample)?)
+            }
+            None => Err(anyhow!("video port required for test sample")),
+        },
+        TestSample::TestPattern => match video_port {
+            Some(port) => start_ffmpeg_send_testsrc(
+                ip,
+                port,
+                Resolution {
+                    width: 1920,
+                    height: 1080,
+                },
+            ),
+            None => Err(anyhow!("video port required for generic")),
+        },
+    }
+}
+
+fn start_ffmpeg_send_from_file(
+    ip: &str,
+    video_port: Option<u16>,
+    audio_port: Option<u16>,
+    path: PathBuf,
+) -> Result<()> {
+    if video_port.is_none() && audio_port.is_none() {
+        return Err(anyhow!(
+            "At least one of: 'video_port', 'audio_port' has to be specified."
+        ));
+    }
+
+    if let Some(port) = video_port {
+        start_ffmpeg_send_video_from_file(ip, port, path.clone())?;
+    }
+    if let Some(port) = audio_port {
+        start_ffmpeg_send_audio_from_file(ip, port, path, "libopus")?
+    }
+
+    Ok(())
+}
+
+fn start_ffmpeg_send_from_file_aac(
+    ip: &str,
+    video_port: Option<u16>,
+    audio_port: Option<u16>,
+    path: PathBuf,
+) -> Result<()> {
+    if video_port.is_none() && audio_port.is_none() {
+        return Err(anyhow!(
+            "At least one of: 'video_port', 'audio_port' has to be specified."
+        ));
+    }
+
+    if let Some(port) = video_port {
+        start_ffmpeg_send_video_from_file(ip, port, path.clone())?;
+    }
+    if let Some(port) = audio_port {
+        start_ffmpeg_send_audio_from_file(ip, port, path, "aac")?
+    }
+
+    Ok(())
+}
+
+fn start_ffmpeg_send_video_from_file(ip: &str, port: u16, path: PathBuf) -> Result<()> {
+    info!("[example] Start sending video to input port {port}.");
+
+    Command::new("ffmpeg")
+        .args(["-re", "-i"])
+        .arg(path)
+        .args([
+            "-an",
+            "-c:v",
+            "copy",
+            "-f",
+            "rtp",
+            "-bsf:v",
+            "h264_mp4toannexb",
+            &format!("rtp://{ip}:{port}?rtcpport={port}"),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    Ok(())
+}
+
+fn start_ffmpeg_send_video_from_file_loop(ip: &str, port: u16, path: PathBuf) -> Result<()> {
+    info!("[example] Start sending video loop to input port {port}.");
+
+    Command::new("ffmpeg")
+        .args(["-stream_loop", "-1", "-re", "-i"])
+        .arg(path)
+        .args([
+            "-an",
+            "-c:v",
+            "copy",
+            "-f",
+            "rtp",
+            "-bsf:v",
+            "h264_mp4toannexb",
+            &format!("rtp://{ip}:{port}?rtcpport={port}"),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    Ok(())
+}
+
+fn start_ffmpeg_send_audio_from_file(
+    ip: &str,
+    port: u16,
+    path: PathBuf,
+    codec: &str,
+) -> Result<()> {
+    info!("[example] Start sending audio to input port {port}.");
+
+    Command::new("ffmpeg")
+        .args(["-stream_loop", "-1", "-re", "-i"])
+        .arg(path.clone())
+        .args([
+            "-vn",
+            "-c:a",
+            codec,
+            "-f",
+            "rtp",
+            &format!("rtp://{ip}:{port}?rtcpport={port}"),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    Ok(())
+}
+
+fn start_ffmpeg_send_testsrc(ip: &str, port: u16, resolution: Resolution) -> Result<()> {
+    info!("[example] Start sending generic video to input port {port}.");
+
+    let ffmpeg_source = format!(
+        "testsrc=s={}x{}:r=30,format=yuv420p",
+        resolution.width, resolution.height
+    );
+
+    Command::new("ffmpeg")
+        .args([
+            "-re",
+            "-f",
+            "lavfi",
+            "-i",
+            &ffmpeg_source,
+            "-c:v",
+            "libx264",
+            "-f",
+            "rtp",
+            &format!("rtp://{ip}:{port}?rtcpport={port}"),
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    Ok(())
+}
+
+/// The SDP file will describe an RTP session on localhost with H264 encoding.
+fn write_video_example_sdp_file(port: u16) -> Result<String> {
+    let ip = "127.0.0.1";
+    let sdp_filepath = PathBuf::from(format!("/tmp/example_sdp_video_input_{}.sdp", port));
+    let mut file = File::create(&sdp_filepath)?;
+    file.write_all(
+        format!(
+            "\
+                    v=0\n\
+                    o=- 0 0 IN IP4 {}\n\
+                    s=No Name\n\
+                    c=IN IP4 {}\n\
+                    m=video {} RTP/AVP 96\n\
+                    a=rtpmap:96 H264/90000\n\
+                    a=fmtp:96 packetization-mode=1\n\
+                    a=rtcp-mux\n\
+                ",
+            ip, ip, port
+        )
+        .as_bytes(),
+    )?;
+    Ok(String::from(
+        sdp_filepath
+            .to_str()
+            .ok_or_else(|| anyhow!("invalid utf string"))?,
+    ))
+}
+
+/// The SDP file will describe an RTP session on localhost with H264 video encoding and Opus audio encoding.
+fn write_video_audio_example_sdp_file(video_port: u16, audio_port: u16) -> Result<String> {
+    let ip = "127.0.0.1";
+    let sdp_filepath = PathBuf::from(format!(
+        "/tmp/example_sdp_video_audio_input_{}.sdp",
+        video_port
+    ));
+    let mut file = File::create(&sdp_filepath)?;
+    file.write_all(
+        format!(
+            "\
+                    v=0\n\
+                    o=- 0 0 IN IP4 {}\n\
+                    s=No Name\n\
+                    c=IN IP4 {}\n\
+                    m=video {} RTP/AVP 96\n\
+                    a=rtpmap:96 H264/90000\n\
+                    a=fmtp:96 packetization-mode=1\n\
+                    a=rtcp-mux\n\
+                    m=audio {} RTP/AVP 97\n\
+                    a=rtpmap:97 opus/48000/2\n\
+                ",
+            ip, ip, video_port, audio_port
+        )
+        .as_bytes(),
+    )?;
+    Ok(String::from(
+        sdp_filepath
+            .to_str()
+            .ok_or_else(|| anyhow!("invalid utf string"))?,
+    ))
+}
+
+/// The SDP file will describe an RTP session on localhost with Opus audio encoding.
+fn write_audio_example_sdp_file(port: u16) -> Result<String> {
+    let ip = "127.0.0.1";
+    let sdp_filepath = PathBuf::from(format!("/tmp/example_sdp_audio_input_{}.sdp", port));
+    let mut file = File::create(&sdp_filepath)?;
+    file.write_all(
+        format!(
+            "\
+                    v=0\n\
+                    o=- 0 0 IN IP4 {}\n\
+                    s=No Name\n\
+                    c=IN IP4 {}\n\
+                    m=audio {} RTP/AVP 97\n\
+                    a=rtpmap:97 opus/48000/2\n\
+                ",
+            ip, ip, port
+        )
+        .as_bytes(),
+    )?;
+    Ok(String::from(
+        sdp_filepath
+            .to_str()
+            .ok_or_else(|| anyhow!("invalid utf string"))?,
+    ))
+}

--- a/integration_tests/src/gstreamer.rs
+++ b/integration_tests/src/gstreamer.rs
@@ -1,0 +1,286 @@
+use anyhow::{anyhow, Result};
+use log::info;
+
+use std::{
+    path::PathBuf,
+    process::{Command, Stdio},
+    thread,
+    time::Duration,
+};
+
+use super::examples::{get_asset_path, TestSample};
+
+pub fn start_gst_receive_tcp(ip: &str, port: u16, video: bool, audio: bool) -> Result<()> {
+    match (video, audio) {
+        (true, true) => info!("[example] Start listening video and audio on port {port}."),
+        (true, false) => info!("[example] Start listening video on port {port}."),
+        (false, true) => info!("[example] Start listening audio on port {port}."),
+        (false, false) => return Err(anyhow!("At least one of: 'video', 'audio' has to be true.")),
+    }
+
+    let mut gst_output_command = [
+        "gst-launch-1.0 -v ",
+        "rtpptdemux name=demux ",
+        &format!("tcpclientsrc host={} port={} ! \"application/x-rtp-stream\" ! rtpstreamdepay ! queue ! demux. ", ip, port)
+        ].concat();
+
+    if video {
+        gst_output_command.push_str("demux.src_96 ! \"application/x-rtp,media=video,clock-rate=90000,encoding-name=H264\" ! queue ! rtph264depay ! decodebin ! videoconvert ! autovideosink ");
+    }
+    if audio {
+        gst_output_command.push_str("demux.src_97 ! \"application/x-rtp,media=audio,clock-rate=48000,encoding-name=OPUS\" ! queue ! rtpopusdepay ! decodebin ! audioconvert ! autoaudiosink ");
+    }
+
+    Command::new("bash")
+        .arg("-c")
+        .arg(gst_output_command)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    thread::sleep(Duration::from_secs(2));
+
+    Ok(())
+}
+
+pub fn start_gst_receive_udp(port: u16, video: bool, audio: bool) -> Result<()> {
+    match (video, audio) {
+        (true, true) => info!("[example] Start listening video and audio on port {port}."),
+        (true, false) => info!("[example] Start listening video on port {port}."),
+        (false, true) => info!("[example] Start listening audio on port {port}."),
+        (false, false) => return Err(anyhow!("At least one of: 'video', 'audio' has to be true.")),
+    }
+
+    let mut gst_output_command = [
+        "gst-launch-1.0 -v ",
+        "rtpptdemux name=demux ",
+        &format!(
+            "udpsrc port={} ! \"application/x-rtp\" ! queue ! demux. ",
+            port
+        ),
+    ]
+    .concat();
+
+    if video {
+        gst_output_command.push_str("demux.src_96 ! \"application/x-rtp,media=video,clock-rate=90000,encoding-name=H264\" ! queue ! rtph264depay ! decodebin ! videoconvert ! autovideosink ");
+    }
+    if audio {
+        gst_output_command.push_str("demux.src_97 ! \"application/x-rtp,media=audio,clock-rate=48000,encoding-name=OPUS\" ! queue ! rtpopusdepay ! decodebin ! audioconvert ! autoaudiosink sync=false");
+    }
+
+    Command::new("bash")
+        .arg("-c")
+        .arg(gst_output_command)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+    thread::sleep(Duration::from_secs(2));
+
+    Ok(())
+}
+
+pub fn start_gst_send_tcp(
+    ip: &str,
+    video_port: Option<u16>,
+    audio_port: Option<u16>,
+    test_sample: TestSample,
+) -> Result<()> {
+    match test_sample {
+        TestSample::BigBuckBunny | TestSample::ElephantsDream | TestSample::Sample => {
+            start_gst_send_from_file_tcp(ip, video_port, audio_port, get_asset_path(test_sample)?)
+        }
+        TestSample::BigBuckBunnyAAC => Err(anyhow!(
+            "GStreamer does not support AAC, try ffmpeg instead"
+        )),
+        TestSample::SampleLoop => Err(anyhow!(
+            "Cannot play sample in loop using gstreamer, try ffmpeg instead."
+        )),
+        TestSample::TestPattern => start_gst_send_testsrc_tcp(ip, video_port, audio_port),
+    }
+}
+
+pub fn start_gst_send_udp(
+    ip: &str,
+    video_port: Option<u16>,
+    audio_port: Option<u16>,
+    test_sample: TestSample,
+) -> Result<()> {
+    match test_sample {
+        TestSample::BigBuckBunny | TestSample::ElephantsDream | TestSample::Sample => {
+            start_gst_send_from_file_udp(ip, video_port, audio_port, get_asset_path(test_sample)?)
+        }
+        TestSample::BigBuckBunnyAAC => Err(anyhow!(
+            "GStreamer does not support AAC, try ffmpeg instead"
+        )),
+        TestSample::SampleLoop => Err(anyhow!(
+            "Cannot play sample in loop using gstreamer, try ffmpeg instead."
+        )),
+        TestSample::TestPattern => start_gst_send_testsrc_udp(ip, video_port, audio_port),
+    }
+}
+
+fn start_gst_send_from_file_tcp(
+    ip: &str,
+    video_port: Option<u16>,
+    audio_port: Option<u16>,
+    path: PathBuf,
+) -> Result<()> {
+    match (video_port, audio_port) {
+        (Some(video_port), Some(audio_port)) => info!(
+            "[example] Start sending video on port {video_port} and audio on port {audio_port}."
+        ),
+        (Some(video_port), None) => info!("[example] Start sending video on port {video_port}."),
+        (None, Some(audio_port)) => info!("[example] Start sending audio on port {audio_port}."),
+        (None, None) => {
+            return Err(anyhow!(
+                "At least one of: 'video_port', 'audio_port' has to be specified."
+            ))
+        }
+    }
+
+    let path = path.to_string_lossy();
+
+    let mut gst_input_command =
+        format!("gst-launch-1.0 -v filesrc location={path} ! qtdemux name=demux ");
+
+    if let Some(port) = video_port {
+        gst_input_command = gst_input_command + &format!("demux.video_0 ! queue ! h264parse ! rtph264pay config-interval=1 !  application/x-rtp,payload=96  ! rtpstreampay ! tcpclientsink host={ip} port={port} ");
+    }
+    if let Some(port) = audio_port {
+        gst_input_command = gst_input_command + &format!("demux.audio_0 ! queue ! decodebin ! audioconvert ! audioresample ! opusenc ! rtpopuspay ! application/x-rtp,payload=97 !  rtpstreampay ! tcpclientsink host={ip} port={port} ");
+    }
+
+    Command::new("bash")
+        .arg("-c")
+        .arg(gst_input_command)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    Ok(())
+}
+
+fn start_gst_send_from_file_udp(
+    ip: &str,
+    video_port: Option<u16>,
+    audio_port: Option<u16>,
+    path: PathBuf,
+) -> Result<()> {
+    match (video_port, audio_port) {
+        (Some(video_port), Some(audio_port)) => info!(
+            "[example] Start sending video on port {video_port} and audio on port {audio_port}."
+        ),
+        (Some(video_port), None) => info!("[example] Start sending video on port {video_port}."),
+        (None, Some(audio_port)) => info!("[example] Start sending audio on port {audio_port}."),
+        (None, None) => {
+            return Err(anyhow!(
+                "At least one of: 'video_port', 'audio_port' has to be specified."
+            ))
+        }
+    }
+
+    let path = path.to_string_lossy();
+
+    let mut gst_input_command = [
+        "gst-launch-1.0 -v ",
+        &format!("filesrc location={path} ! qtdemux name=demux "),
+    ]
+    .concat();
+
+    if let Some(port) = video_port {
+        gst_input_command = gst_input_command + &format!("demux.video_0 ! queue ! h264parse ! rtph264pay config-interval=1 !  application/x-rtp,payload=96  ! udpsink host={ip} port={port} ");
+    }
+    if let Some(port) = audio_port {
+        gst_input_command = gst_input_command + &format!("demux.audio_0 ! queue ! decodebin ! audioconvert ! audioresample ! opusenc ! rtpopuspay ! application/x-rtp,payload=97 ! udpsink host={ip} port={port} ");
+    }
+
+    Command::new("bash")
+        .arg("-c")
+        .arg(gst_input_command)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    Ok(())
+}
+
+fn start_gst_send_testsrc_tcp(
+    ip: &str,
+    video_port: Option<u16>,
+    audio_port: Option<u16>,
+) -> Result<()> {
+    match (video_port, audio_port) {
+        (Some(video_port), Some(audio_port)) => info!(
+            "[example] Start sending generic video on port {video_port} and audio on port {audio_port}."
+        ),
+        (Some(video_port), None) => info!("[example] Start sending generic video on port {video_port}."),
+        (None, Some(audio_port)) => info!("[example] Start sending generic audio on port {audio_port}."),
+        (None, None) => {
+            return Err(anyhow!(
+                "At least one of: 'video_port', 'audio_port' has to be specified."
+            ))
+        }
+    }
+
+    let mut gst_input_command = [
+        "gst-launch-1.0 -v videotestsrc ! ",
+        "\"video/x-raw,format=I420,width=1920,height=1080,framerate=60/1\" ! ",
+    ]
+    .concat();
+
+    if let Some(port) = video_port {
+        gst_input_command = gst_input_command + &format!(" x264enc tune=zerolatency speed-preset=superfast ! rtph264pay ! application/x-rtp,payload=96 ! rtpstreampay ! tcpclientsink host={ip} port={port}");
+    }
+    if let Some(port) = audio_port {
+        gst_input_command = gst_input_command + &format!(" audiotestsrc ! audioconvert ! audioresample ! opusenc ! rtpopuspay ! application/x-rtp,payload=97 ! rtpstreampay ! tcpclientsink host={ip} port={port}");
+    }
+
+    Command::new("bash")
+        .arg("-c")
+        .arg(gst_input_command)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    Ok(())
+}
+
+fn start_gst_send_testsrc_udp(
+    ip: &str,
+    video_port: Option<u16>,
+    audio_port: Option<u16>,
+) -> Result<()> {
+    match (video_port, audio_port) {
+        (Some(video_port), Some(audio_port)) => info!(
+            "[example] Start sending generic video on port {video_port} and audio on port {audio_port}."
+        ),
+        (Some(video_port), None) => info!("[example] Start sending generic video on port {video_port}."),
+        (None, Some(audio_port)) => info!("[example] Start sending generic audio on port {audio_port}."),
+        (None, None) => {
+            return Err(anyhow!(
+                "At least one of: 'video_port', 'audio_port' has to be specified."
+            ))
+        }
+    }
+
+    let mut gst_input_command = [
+        "gst-launch-1.0 -v videotestsrc ! ",
+        "\"video/x-raw,format=I420,width=1920,height=1080,framerate=60/1\" ! ",
+    ]
+    .concat();
+
+    if let Some(port) = video_port {
+        gst_input_command = gst_input_command + &format!(" x264enc tune=zerolatency speed-preset=superfast ! rtph264pay ! application/x-rtp,payload=96 ! udpsink host={ip} port={port}");
+    }
+    if let Some(port) = audio_port {
+        gst_input_command = gst_input_command + &format!(" audiotestsrc ! audioconvert ! audioresample ! opusenc ! rtpopuspay ! application/x-rtp,payload=97 ! udpsink host={ip} port={port}");
+    }
+
+    Command::new("bash")
+        .arg("-c")
+        .arg(gst_input_command)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    Ok(())
+}

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -8,6 +8,8 @@ mod validation;
 mod video_decoder;
 
 pub mod examples;
+pub mod ffmpeg;
+pub mod gstreamer;
 pub mod test_input;
 
 #[cfg(test)]


### PR DESCRIPTION
issue https://github.com/membraneframework/live_compositor/issues/603 - examples dir refactor + cleanup

- added more general function for streaming with gstreamer and ffmpeg
- added possibility to stream any combination of video and audio using both gstreamer and ffmpeg
- added functions allowing for creating ffmpeg and gstreamer streams with predefined samples easily