### PR TITLE
Fix input queueing when some of the inputs do not produce frames/samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### 🐛 Bug fixes
 
+- Fix input queueing when some of the inputs do not produce frames/samples . ([#625](https://github.com/membraneframework/live_compositor/pull/625) by [@wkozyra95](https://github.com/wkozyra95))
+
 ## [v0.2.0](https://github.com/membraneframework/live_compositor/releases/tag/v0.2.0)
 
 Initial release

--- a/compositor_pipeline/src/queue/audio_queue.rs
+++ b/compositor_pipeline/src/queue/audio_queue.rs
@@ -153,6 +153,9 @@ impl AudioQueueInput {
         pts_range: (Duration, Duration),
         queue_start: Instant,
     ) -> PipelineEvent<Vec<InputSamples>> {
+        // ignore result, we only need to ensure samples are enqueued
+        self.check_ready_for_pts(pts_range, queue_start);
+
         // range in queue pts time frame
         let (start_pts, end_pts) = pts_range;
 

--- a/compositor_pipeline/src/queue/video_queue.rs
+++ b/compositor_pipeline/src/queue/video_queue.rs
@@ -158,6 +158,9 @@ impl VideoQueueInput {
         buffer_pts: Duration,
         queue_start: Instant,
     ) -> Option<PipelineEvent<Frame>> {
+        // ignore result, we only need to ensure frames are enqueued
+        self.check_ready_for_pts(buffer_pts, queue_start);
+
         self.drop_old_frames(buffer_pts, queue_start);
         let input_start_time = self.input_start_time()?;
         let frame = match self.offset {


### PR DESCRIPTION
Steps to reproduce:
- start more than one stream when one of them is shorter than the others
- when the first stream is finished other streams might disappear

What happens:
- normally queue is
  - checking if all inputs are ready (and pulling from channel if necessary)
  - for each input:
    - dropping old frames
    - taking first frame (first not dropped should be the one we want to use)
- if one input is done without sending EOS, but just stops sending data
  - checking if all inputs are ready is lazy, so if it checks that one specific input that ended it does not check any further
  - for each input:
    - dropping old frames will work, but because previous step did not enqueue new frames from the channel we are left with one outdated frame
    - taking first frame return old frame (latter renderer can see that frame is older by more than 500ms and drops it, replacing with a black screen)
  
  
Alternative approach could be to replace call to `any` https://github.com/membraneframework/live_compositor/blob/master/compositor_pipeline/src/queue/video_queue.rs#L103 with non-lazy alternative, but I think this is cleaner.